### PR TITLE
tui-calendar 추가시 js 로드 부분 개선

### DIFF
--- a/src/main/resources/static/js/app/calendar.js
+++ b/src/main/resources/static/js/app/calendar.js
@@ -3,6 +3,7 @@ var calendar = {
         var cal = new tui.Calendar('#calendar', {
             defaultView: 'month' // monthly view option
         });
+        console.log(cal);
     }
 }
 

--- a/src/main/resources/templates/calendar.mustache
+++ b/src/main/resources/templates/calendar.mustache
@@ -1,4 +1,4 @@
-{{>layout/header}}
+{{>layout/header }}
 <div class="code-html">
     <div id="menu">
       <span id="menu-navi">
@@ -12,12 +12,13 @@
       </span>
         <span id="renderRange" class="render-range">2021.01</span>
     </div>
-    <div id="calendar"></div>
+    <div id="calendar" style="height: 800px;"></div>
 </div>
 <!-- tui.calendar -->
-<script type="text/javascript" src="https://uicdn.toast.com/tui.code-snippet/latest/tui-code-snippet.js"></script>
-<script type="text/javascript" src="https://uicdn.toast.com/tui.time-picker/latest/tui-time-picker.min.js"></script>
-<script type="text/javascript" src="https://uicdn.toast.com/tui.date-picker/latest/tui-date-picker.min.js"></script>
-<script type="text/javascript" src="https://uicdn.toast.com/tui-calendar/latest/tui-calendar.js"></script>
-<script type="text/javascript" src="/js/app/calendar.js"></script>
+{{! https://github.com/nhn/tui.calendar/issues/378 참고함, Jquery 미존재 버전 형태임,  }}
+  <script type="text/javascript" src="https://uicdn.toast.com/tui.dom/v3.0.0/tui-dom.js">
+  <script type="text/javascript" src="https://uicdn.toast.com/tui.time-picker/latest/tui-time-picker.min.js"></script>
+  <script type="text/javascript" src="https://uicdn.toast.com/tui.date-picker/latest/tui-date-picker.min.js"></script>
+  <script type="text/javascript" src="https://uicdn.toast.com/tui-calendar/latest/tui-calendar.js"></script>
+  <script type="text/javascript" src="/js/app/calendar.js"></script>
 {{>layout/footer}}

--- a/src/main/resources/templates/layout/header.mustache
+++ b/src/main/resources/templates/layout/header.mustache
@@ -4,6 +4,8 @@
     <title>스프링 부트 웹서비스</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    
+    <script type="text/javascript" src="https://uicdn.toast.com/tui.code-snippet/latest/tui-code-snippet.js"></script>
     <link rel="stylesheet" href="https://uicdn.toast.com/tui-calendar/latest/tui-calendar.css">
     <!-- If you use the default popups, use this. -->
     <link rel="stylesheet" href="https://uicdn.toast.com/tui.date-picker/latest/tui-date-picker.css">


### PR DESCRIPTION
- update: tui.calendar의 이슈중 spring boot에서 사용시 적용 방안에 대한 부분 참조하여 수정(jquery 미적용 버전으로 tui-dom.js lib 사용)
- update: tui.calendar의 가이드상 css3개와 tui-code-snippet.js 는 header 영역에 존재하도록 배치 변경