### PR TITLE
tui-dom.js의 script 마침테그 없는 오류 및 주석 추가

### DIFF
--- a/src/main/resources/templates/calendar.mustache
+++ b/src/main/resources/templates/calendar.mustache
@@ -1,4 +1,5 @@
 {{>layout/header }}
+<!-- 아래 영역은 bootstrap의 style이 적용되는 영역입니다. tui.calendar는 달력 상단 영역에 대해서는 가이드 하지 않고 있어서 개별 생성 해야 합니다. -->
 <div class="code-html">
     <div id="menu">
       <span id="menu-navi">
@@ -15,8 +16,8 @@
     <div id="calendar" style="height: 800px;"></div>
 </div>
 <!-- tui.calendar -->
-{{! https://github.com/nhn/tui.calendar/issues/378 참고함, Jquery 미존재 버전 형태임,  }}
-  <script type="text/javascript" src="https://uicdn.toast.com/tui.dom/v3.0.0/tui-dom.js">
+{{! https://github.com/nhn/tui.calendar/issues/378 李멸퀬�븿, Jquery 誘몄〈�옱 踰꾩쟾 �삎�깭�엫,  }}
+  <script type="text/javascript" src="https://uicdn.toast.com/tui.dom/v3.0.0/tui-dom.js"></script>
   <script type="text/javascript" src="https://uicdn.toast.com/tui.time-picker/latest/tui-time-picker.min.js"></script>
   <script type="text/javascript" src="https://uicdn.toast.com/tui.date-picker/latest/tui-date-picker.min.js"></script>
   <script type="text/javascript" src="https://uicdn.toast.com/tui-calendar/latest/tui-calendar.js"></script>


### PR DESCRIPTION
- update: tui-dom.js의 </script> 부분 추가
- update: calendar 상단 영역의 버튼 생성은 tui.calendar에서 지원하지 않으므로, bootstrap의 style 로 적용 해야함(https://getbootstrap.com/docs/4.0/components/buttons/)
- 버튼이 보이지 않는 현상은 tui.calendar의 샘플 화면내의 class를 적용하였으나, 샘플 화면에서는 calendar 이외에는 별도 제작한 영역으로 가이드된 css 이외의 css 등이 포함되어 적용 되어야 버튼이 보입니다. 하지만 샘플 화면에서 쓰고 있는 css를 강제로 link 하면 bootstrap의 css가 깨지면서 상단 영역이 calendar에 가려지는 현상이 있어서, 상단은 bootstrap의 class naming에 맞춰서 적용 하셔야 합니다.
-  좌 / 우 버튼에 대한 아이콘은 'https://icons.getbootstrap.com/'에서 icon 영역에서 'Copy HTML' 영역의 내용을 버튼 안에 넣으시면 됩니다.